### PR TITLE
add complection for local packages

### DIFF
--- a/src/NpmIntellisense.ts
+++ b/src/NpmIntellisense.ts
@@ -1,49 +1,71 @@
-import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind, workspace } from 'vscode'
+import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind, workspace } from 'vscode';
 import { readFile } from 'fs';
 import { join } from 'path';
+import { localPackages } from './local';
 
 const packageJson = join(workspace.rootPath, 'package.json');
+const tsConfigJson = join(workspace.rootPath, 'tsconfig.json');
 const scanDevDependencies = workspace.getConfiguration('npm-intellisense')['scanDevDependencies'];
 
 export class NpmIntellisense implements CompletionItemProvider {
     provideCompletionItems(document: TextDocument, position: Position): Thenable<CompletionItem[]> {
-        if (!this.shouldProvide(document, position)) { return Promise.resolve([]) } 
-        return this.getNpmPackages().then(dependencies => dependencies.map(d => this.toCompletionItem(d)));
+        const line = document.getText(document.lineAt(position).range);
+        if (!this.isImportOrRequire(line)) {
+            return Promise.resolve([]);
+        }
+
+        const text = this.getTextWithinString(line, position.character);
+        const searchLocal = text.startsWith('.');
+        const searchGlobal = !text && !searchLocal;
+
+        const all: CompletionItem[] = [];
+        function add(items: CompletionItem[]): CompletionItem[] {
+            items.forEach(it => all.push(it));
+            return all;
+        }
+
+        return this.readFilePromise(packageJson).then(config => {
+            let p: Promise<CompletionItem[]> = Promise.resolve(all);
+            if (searchLocal) {
+                const locals = tsConfigOrErr => localPackages(workspace.rootPath, document.fileName, text, tsConfigOrErr.exclude).then(add);
+                p = this.readFilePromise(tsConfigJson)
+                    .then(locals)
+                    .catch(locals);
+            }
+            if (searchGlobal) {
+                p = p.then(() => Promise.resolve(add(this.getNpmPackages(config).map(d => this.toCompletionItem(d)))));
+            }
+
+            return p;
+        });
     }
-    
-    getNpmPackages() {
-        return this.readFilePromise(packageJson)
-            .then(config => [
-                ...Object.keys(config.dependencies || {}), 
-                ...Object.keys(scanDevDependencies ? config.devDependencies || {} : {})
-                ])
-            .catch(() => []);
+
+    getNpmPackages(config) {
+        return [
+            ...Object.keys(config.dependencies || {}),
+            ...Object.keys(scanDevDependencies ? config.devDependencies || {} : {})
+        ];
     }
-    
+
     readFilePromise(file) {
         return new Promise<any>((resolve, reject) => {
             readFile(file, (err, data) => err ? reject(err) : resolve(JSON.parse(data.toString())));
         });
     }
-    
+
     toCompletionItem(dep: string) {
         let item = new CompletionItem(dep);
         item.kind = CompletionItemKind.Module;
         return item;
     }
-    
-    shouldProvide(document: TextDocument, position: Position) {
-        const line = document.getText(document.lineAt(position).range);
-        return this.isImportOrRequire(line) && this.getTextWithinString(line, position.character) === ""; 
-    }
-    
-    isImportOrRequire(line: string) {
+
+    isImportOrRequire(line: string) {
         let isImport = line.substring(0, 6) === 'import';
         let isRequire = line.indexOf('require(') != -1;
         return isImport || isRequire;
     }
-    
-    getTextWithinString(line: string, position: number) {
+
+    getTextWithinString(line: string, position: number) {
         const textToPosition = line.substring(0, position);
         const quoatationPosition = Math.max(textToPosition.lastIndexOf('\"'), textToPosition.lastIndexOf('\''));
         return quoatationPosition != -1 ? textToPosition.substring(quoatationPosition + 1, textToPosition.length) : undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,12 @@
 'use strict';
 import { ExtensionContext, languages, DocumentSelector } from 'vscode';
 import { NpmIntellisense } from './NpmIntellisense';
+import { LANGUAGES } from './languages';
 
 export function activate(context: ExtensionContext) {
 	const provider = new NpmIntellisense();
-	const triggers = ['"', '\''];
-    const selector = ['typescript', 'javascript', 'javascriptreact', 'typescriptreact'];
+	const triggers = ['"', '\'', '.'];
+    const selector = Object.keys(LANGUAGES);
 	context.subscriptions.push(languages.registerCompletionItemProvider(selector, provider, ...triggers));
 }
 

--- a/src/fs-rider.ts
+++ b/src/fs-rider.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+interface FileFun {
+    (file: string, fullPath: string): void;
+}
+
+function accept(cwd: string, exclude: FileFun, visit: FileFun) {
+    fs.readdirSync(cwd).forEach(file => {
+        const full = path.join(cwd, file);
+        if (exclude(file, full)) {
+            return;
+        }
+        if (fs.lstatSync(full).isDirectory()) {
+            accept(full, exclude, visit);
+        } else {
+            visit(file, full);
+        }
+    });
+}
+
+export function rideDirectoryTree(cwd: string, excludes: string[] = [], matcher: (file: string) => boolean): string[] {
+
+    const result: string[] = [];
+
+    function visit(file: string, full: string) {
+        if (matcher(full)) {
+            result.push(path.relative(cwd, full).replace(/\\/g, '/'));
+        }
+    }
+
+    function exclude(file: string, path: string): boolean {
+        return excludes.indexOf(file) >= 0 || file[0] === '.';
+    }
+
+    accept(cwd, exclude, visit);
+
+    return result;
+}

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,0 +1,9 @@
+/**
+ * All supported languages mapped to their file extension.
+ */
+export const LANGUAGES = {
+    'typescript': '.ts',
+    'javascript': '.js',
+    'javascriptreact': '.jsx',
+    'typescriptreact': '.tsx'
+};

--- a/src/local.ts
+++ b/src/local.ts
@@ -1,0 +1,83 @@
+import { CompletionItemProvider, TextDocument, Position, CompletionItem, CompletionItemKind, workspace } from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+
+import { LANGUAGES } from './languages';
+import * as fsRider from './fs-rider';
+
+const INDEX = '/index';
+
+const EXTENSIONS = {};
+Object.keys(LANGUAGES).forEach(it => EXTENSIONS[LANGUAGES[it]] = true);
+
+function matcher(file: string) {
+    const ext = file.substring(file.lastIndexOf('.'));
+    return EXTENSIONS[ext];
+}
+
+/**
+ * Searches for packages/files underneath fileName's parent folder, that start with the given prefix.
+ * @return undefined if prefix does not start with a dot (.)
+ */
+export function localPackages(root: string, fileName: string, prefix: string, exclude: string[]): Promise<CompletionItem[]> {
+
+    const none = Promise.resolve([]);
+
+    const dirname = path.dirname(fileName);
+    const cwdCandidate = path.join(dirname, prefix);
+
+    const parentUsed = !fs.existsSync(cwdCandidate);
+    const cwd = parentUsed ? path.dirname(cwdCandidate) : cwdCandidate;
+
+    try {
+        if (fs.realpathSync(cwd).length < fs.realpathSync(root).length) {
+            return none;
+        }
+    } catch (err) {
+        return none;
+    }
+
+    const matchPrefix = prefix.endsWith('/') ? '' : '/';
+
+    function toLabel(match: string): string {
+        match = match.substring(0, match.lastIndexOf('.'));
+        if (match.endsWith(INDEX)) {
+            match = match.substring(0, match.length - INDEX.length);
+        }
+        return matchPrefix + match;
+    }
+
+    function notSelf(match: string): boolean {
+        return path.join(dirname, match) !== fileName;
+    }
+
+    const existingLabels = {};
+    function dups(label: string): boolean {
+        if (existingLabels[label]) {
+            return false;
+        }
+        return existingLabels[label] = true;
+    }
+
+    return new Promise((resolve, reject) => {
+        try {
+            const matches = fsRider.rideDirectoryTree(cwd, exclude, matcher);
+
+            function toCompletionItem(label: string): CompletionItem {
+                const it = new CompletionItem(label);
+                it.insertText = parentUsed ? label.substring(1) : label;
+                it.kind = CompletionItemKind.Module;
+                return it;
+            }
+
+            resolve(matches
+                .filter(notSelf)
+                .map(toLabel)
+                .filter(dups)
+                .map(toCompletionItem));
+
+        } catch (err) {
+            reject(err);
+        }
+    });
+}


### PR DESCRIPTION
Hi, 
thanks for your useful plugin!
This pull request add completion for local packages. After typing . (dot) within an import statement, it searches the file system for .ts, .js...etc. ../ paths are also supported and stops going further up at the workspace folder. It honours the "exclude" setting in "tsconfig.json" (if present).
The current behaviour is still there; either local or global modules are completed, depending whether the first character is a dot.
Let me know what you think of it or if can add anything more. Hopefully, it could make it into your product.