### PR TITLE
Generate import statements via quickpick/search in node_modules and root

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
          "onLanguage:typescript",
          "onLanguage:javascript",
          "onLanguage:javascriptreact",
-         "onLanguage:typescriptreact"
+         "onLanguage:typescriptreact",
+         "onCommand:npm-intellisense.import"
     ],
     "contributes": {
         "configuration": {
@@ -30,9 +31,35 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Scans devDependencies as well"
+                },
+                "npm-intellisense.importES6": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use import statements instead of require()"
+                },
+                "npm-intellisense.importQuotes": {
+                    "type": "string",
+                    "default": "'",
+                    "description": "The type of quotes to use in the snippet"
+                },
+                "npm-intellisense.importLinebreak": {
+                    "type": "string",
+                    "default": ";\r\n",
+                    "description": "The linebreak used after the snippet"
+                },
+                "npm-intellisense.importDeclarationType": {
+                    "type": "string",
+                    "default": "const",
+                    "description": "The declaration type used for require()"
                 }
             }
-        }    
+        },
+        "commands": [
+            {
+                "command": "npm-intellisense.import",
+                "title": "JavaScript: Import a module"
+            }
+        ]
     },
     "icon": "images/icon.png",
     "main": "./out/src/extension",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,44 @@
 'use strict';
-import { ExtensionContext, languages, DocumentSelector, workspace } from 'vscode';
+import { ExtensionContext, languages, workspace, commands, window, TextEditorEdit } from 'vscode';
 import { NpmIntellisense } from './NpmIntellisense';
+import { getQuickPickItems, getImportStatementFromFilepath } from './util';
 
 export function activate(context: ExtensionContext) {
 	if (workspace.rootPath) {
 		const provider = new NpmIntellisense();
 		const triggers = ['"', '\''];
-	    const selector = ['typescript', 'javascript', 'javascriptreact', 'typescriptreact'];
+	  const selector = ['typescript', 'javascript', 'javascriptreact', 'typescriptreact'];
 		context.subscriptions.push(languages.registerCompletionItemProvider(selector, provider, ...triggers));
+
+		var disposable = commands.registerCommand('npm-intellisense.import', () => {
+
+			window.showQuickPick(
+				provider.getNpmPackages()
+					.then(getQuickPickItems)
+					.catch(error => {
+						window.showErrorMessage(error);
+					}),
+					{
+						matchOnDescription: true
+					}
+			)
+				.then( ( item:any ) => {
+
+					let statement:string = getImportStatementFromFilepath(item.filePath);
+
+					window.activeTextEditor.edit(
+						( edit:TextEditorEdit ) => {
+							edit.insert(
+								window.activeTextEditor.selection.start,
+								statement
+							)
+						}
+					)
+				});
+		});
 	}
+	
+	context.subscriptions.push(disposable);
 }
 
 export function deactivate() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,115 @@
+'use_strict';
+import { workspace, window } from 'vscode';
+import { readdir, stat } from 'fs';
+import { join, sep, relative, extname } from 'path';
+
+export const isDirectory = ( path ):Promise<boolean> => {
+	return new Promise(( resolve, reject ) => {
+		stat(path, ( error, stats ) => {
+			if (error) {
+				reject(error);
+			} else {
+				resolve(stats.isDirectory());
+			}
+		});
+	});
+};
+
+export const readFilesFromDir = ( dir:string ):Promise<Array<string>> => {
+
+	return new Promise<Array<string>>(( resolve, reject ) => {
+		let paths:Array<string> = [];
+		readdir(dir, ( error, files ) => {
+
+			Promise.all(
+				files.map(file => {
+					const path = join(dir, file);
+
+					if (file === 'node_modules') {
+						return Promise.resolve([]);
+					}
+
+					return isDirectory(path)
+						.then(isDir => isDir ? readFilesFromDir(path) : Promise.resolve( [ path ]));
+
+				})
+			)
+				.then(( filesPerDir:Array<any> ) => {
+					resolve([].concat(...filesPerDir))
+				})
+				.catch(error => reject(error));
+			
+		});
+	});
+
+}
+
+export const readFilesFromPackage = ( packageName:string ):Promise<Array<string>> => {
+	return readFilesFromDir(
+		join(workspace.rootPath, 'node_modules', packageName)
+	);
+}
+
+export const getQuickPickItems = ( packages:Array<string> ):Promise<any> => {
+
+	const root = workspace.rootPath;
+	const nodeRegEx = new RegExp(`^node_modules\\${sep}`);
+
+	return Promise.all(
+		[ readFilesFromDir(root) ].concat(packages.map(readFilesFromPackage))
+	)
+		.then(( filesPerPackage:Array<any> ) => {
+			let items:Array<any> =
+				[].concat(...filesPerPackage)
+					.map( ( filePath:string ) => {
+						const partialPath:string = filePath.replace(root + sep, '').replace(nodeRegEx, '');
+						const fragments:Array<string> = partialPath.split(sep);
+						const label:string = fragments[fragments.length-1];
+						const description:string = fragments.join('/');
+
+						return { label, description, filePath };
+					});
+
+			return items;
+		})
+};
+
+export const getImportStatementFromFilepath = ( filePath:string ):string => {
+	let partialPath:string = !filePath.includes('node_modules') ?
+			relative(window.activeTextEditor.document.fileName, filePath)
+			: filePath.replace(join(workspace.rootPath, 'node_modules') + sep, '');
+
+		let fragments:Array<string> =
+			filePath.split(sep)
+				.map( ( fragment:string, index:number, arr:Array<any> ) => {
+					return index === arr.length - 1 ?
+						fragment.replace(/\.js$/, '')
+							.replace(/^index$/, '')
+						: fragment;
+				})
+				.filter(fragment => !!fragment);
+
+		let moduleName:string = fragments[fragments.length - 1]
+			.replace(/[\-](.)/g, ( substring:string, ...rest:Array<any> ) => rest[0].toUpperCase());
+
+		moduleName = moduleName.replace(new RegExp(`${extname(moduleName)}$`), '')
+			.replace(/^[^a-z$]/i, '');
+
+		let packagePath:string = partialPath.split(sep).filter(fragment => fragment !== 'index.js').join('/') || '.';
+
+		let importES6:boolean = workspace.getConfiguration('npm-intellisense')['importES6'];
+		let quoteType:string = workspace.getConfiguration('npm-intellisense')['importQuotes'];
+		let linebreak:string = workspace.getConfiguration('npm-intellisense')['importLinebreak'];
+		let declaration:string = workspace.getConfiguration('npm-intellisense')['importDeclarationType'];
+		let statement:string;
+
+		if (importES6) {
+			statement = `import ${moduleName} from ${quoteType}${packagePath}${quoteType}` 
+		} else {
+			statement = `${declaration} ${moduleName} = require(${quoteType}${packagePath}${quoteType})`
+		}
+
+		statement += `${linebreak}`;
+
+		return statement;
+};


### PR DESCRIPTION
This implements an `npm-intellisense.import` commands, which shows a quickpick box to the user, populated with files in the current project, and contents in node_modules from packages defined in package.json (via `getPackages`).

When the user selects a file, an import snippet is pasted at the current position on the active text editor. Via settings, the user can configure whether import or require should be used, whether to use single or double quotes, and which linebreak and declaration type to use. 