### PR TITLE
Fixed 'Unexpected token '/'' in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,18 @@
         "vscode": "^1.0.0"
     },
     "homepage": "https://github.com/ChristianKohler/NpmIntellisense",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/ChristianKohler/NpmIntellisense.git"
-	},
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChristianKohler/NpmIntellisense.git"
+    },
     "categories": [
         "Other"
     ],
     "activationEvents": [
-         "onLanguage:typescript",
-         "onLanguage:javascript",
-         "onLanguage:javascriptreact",
-         "onLanguage:typescriptreact"
-        //  "onCommand:npm-intellisense.import"
+        "onLanguage:typescript",
+        "onLanguage:javascript",
+        "onLanguage:javascriptreact",
+        "onLanguage:typescriptreact"
     ],
     "contributes": {
         "configuration": {
@@ -42,26 +41,6 @@
                     "default": false,
                     "description": "(experimental) Enables path intellisense in subfolders of modules"
                 }
-                // "npm-intellisense.importES6": {
-                //     "type": "boolean",
-                //     "default": true,
-                //     "description": "Use import statements instead of require()"
-                // },
-                // "npm-intellisense.importQuotes": {
-                //     "type": "string",
-                //     "default": "'",
-                //     "description": "The type of quotes to use in the snippet"
-                // },
-                // "npm-intellisense.importLinebreak": {
-                //     "type": "string",
-                //     "default": ";\r\n",
-                //     "description": "The linebreak used after the snippet"
-                // },
-                // "npm-intellisense.importDeclarationType": {
-                //     "type": "string",
-                //     "default": "const",
-                //     "description": "The declaration type used for require()"
-                // }
             }
         },
         "commands": [


### PR DESCRIPTION
Fixed for issue when running `npm install` on a new clone that would cause:

> bash-3.2$ npm install
npm ERR! Darwin 16.3.0
npm ERR! argv "/usr/local/Cellar/node/7.2.1/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v7.2.1
npm ERR! npm  v3.10.9
npm ERR! file <...>/dev/NpmIntellisense/package.json
npm ERR! code EJSONPARSE
npm ERR! Failed to parse json
npm ERR! Unexpected token '/' at 23:9
npm ERR!         //  "onCommand:npm-intellisense.import"
npm ERR!         ^
npm ERR! File: <...>/dev/NpmIntellisense/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR!
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse
npm ERR! Please include the following file with any support request:
npm ERR!     <...>/dev/NpmIntellisense/npm-debug.log