### PR TITLE
Correct spelling of "built in libs" throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Npm intellisense scans only dependencies by default. Set scanDevDependencies to 
 }
 ```
 
-### Show build in (local) libs
-Shows build in node modules like 'path' of 'fs'
+### Show built in (local) libs
+Shows built in node modules like 'path' or 'fs'
 
 ```javascript
 {
-	"npm-intellisense.showBuildInLibs": true,
+	"npm-intellisense.showBuiltInLibs": true,
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,19 +8,19 @@
         "vscode": "^1.0.0"
     },
     "homepage": "https://github.com/ChristianKohler/NpmIntellisense",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/ChristianKohler/NpmIntellisense.git"
-	},
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChristianKohler/NpmIntellisense.git"
+    },
     "categories": [
         "Other"
     ],
     "activationEvents": [
-         "onLanguage:typescript",
-         "onLanguage:javascript",
-         "onLanguage:javascriptreact",
-         "onLanguage:typescriptreact",
-         "onCommand:npm-intellisense.import"
+        "onLanguage:typescript",
+        "onLanguage:javascript",
+        "onLanguage:javascriptreact",
+        "onLanguage:typescriptreact",
+        "onCommand:npm-intellisense.import"
     ],
     "contributes": {
         "configuration": {
@@ -42,10 +42,10 @@
                     "default": false,
                     "description": "(experimental) Enables path intellisense in subfolders of modules"
                 },
-                "npm-intellisense.showBuildInLibs": {
+                "npm-intellisense.showBuiltInLibs": {
                     "type": "boolean",
                     "default": false,
-                    "description": "shows build in node modules like 'path' of 'fs'"
+                    "description": "shows built in node modules like 'path' or 'fs'"
                 },
                 "npm-intellisense.importES6": {
                     "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,24 +4,24 @@ export interface Config {
     scanDevDependencies?: boolean,
     recursivePackageJsonLookup?: boolean,
     packageSubfoldersIntellisense?: boolean,
-    showBuildInLibs?: boolean,
+    showBuiltInLibs?: boolean,
     importES6?: boolean,
     importQuotes?: string,
     importLinebreak?: string,
     importDeclarationType?: string
 }
 
-export function getConfig() : Config {
+export function getConfig(): Config {
     const configuration = workspace.getConfiguration('npm-intellisense');
 
     return {
         scanDevDependencies: configuration['scanDevDependencies'],
         recursivePackageJsonLookup: configuration['recursivePackageJsonLookup'],
         packageSubfoldersIntellisense: configuration['packageSubfoldersIntellisense'],
-        showBuildInLibs: configuration['showBuildInLibs'],
+        showBuiltInLibs: configuration['showBuiltInLibs'],
         importES6: configuration['importES6'],
-        importQuotes:configuration['importQuotes'],
-        importLinebreak:configuration['importLinebreak'],
+        importQuotes: configuration['importQuotes'],
+        importLinebreak: configuration['importLinebreak'],
         importDeclarationType: configuration['importDeclarationType']
     };
 }

--- a/src/provide.ts
+++ b/src/provide.ts
@@ -20,12 +20,12 @@ export function getNpmPackages(state: State, config: Config, fsf: FsFunctions) {
         .then(packageJson => [
             ...Object.keys(packageJson.dependencies || {}),
             ...Object.keys(config.scanDevDependencies ? packageJson.devDependencies || {} : {}),
-            ...(config.showBuildInLibs ? getBuildInModules() : [])
+            ...(config.showBuiltInLibs ? getBuiltInModules() : [])
         ])
         .catch(() => []);
 }
 
-function getBuildInModules() : string[] {
+function getBuiltInModules(): string[] {
     return (<any>repl)._builtinLibs;
 }
 

--- a/test/provide.test.ts
+++ b/test/provide.test.ts
@@ -7,7 +7,7 @@ import { FsFunctions } from '../src/fs-functions';
 suite("provide Tests", () => {
     test("Should read dependencies", (done: MochaDone) => {
         const state = createState();
-        const config : Config = { };
+        const config: Config = {};
         const fsf = createFsf();
 
         provide(state, config, fsf)
@@ -38,10 +38,10 @@ suite("provide Tests", () => {
             .catch(err => done(err));
     });
 
-    test("Should show build in node modules when enabled", (done: MochaDone) => {
+    test("Should show built in node modules when enabled", (done: MochaDone) => {
         const state = createState();
         const config: Config = {
-            showBuildInLibs: true
+            showBuiltInLibs: true
         };
         const fsf = createFsf();
 
@@ -90,7 +90,7 @@ function createFsf(): FsFunctions {
     };
 }
 
-function readJsonMock(path) : Promise<any> {
+function readJsonMock(path): Promise<any> {
     switch (path) {
         case '/User/dummy/project/src/package.json':
             return Promise.resolve({


### PR DESCRIPTION
The config flag `npm-intellisense.showBuiltInLibs` was misspelt as `npm-intellisense.showBuildInLibs`(along with another typo in the flag description).

I've corrected the spelling. If this breaks old configs I am happy to add backwards compatibility by reading the deprecated flag as well as the new one.