### PR TITLE
Add a GitHub Action to publish to GitHub releases, OpenVSX and the MS Marketplace

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,8 +44,6 @@ jobs:
         run: echo "::set-output name=packageName::$(node -e "console.log(require('./package.json').name + '-' + require('./package.json').version + '.vsix')")"
 
       - name: Package
-        env:
-          VSIX_PACKAGE_PATH: ${{ steps.setup.outputs.packageName }}
         run: npx vsce package --packagePath ${{ steps.setup.outputs.packageName }}
       
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
           VSIX_PACKAGE_PATH: ${{ steps.setup.outputs.packageName }}
         run: |
           npm i -g vsce
-          vsce pacakge
+          vsce package
       
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,9 +46,7 @@ jobs:
       - name: Package
         env:
           VSIX_PACKAGE_PATH: ${{ steps.setup.outputs.packageName }}
-        run: |
-          npm i -g vsce
-          vsce package
+        run: npx vsce package --packagePath ${{ steps.setup.outputs.packageName }}
       
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,125 @@
+name: Release
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      publishMS:
+        description: 'Publish to MS marketplace'
+        type: boolean
+        required: true
+        default: "true"
+      publishOVSX:
+        description: 'Publish to OpenVSX'
+        type: boolean
+        required: true
+        default: "true"
+      publishGH:
+        description: 'Publish to GitHub releases'
+        type: boolean
+        required: true
+        default: "true"
+
+jobs:
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    outputs:
+      packageName: ${{ steps.setup.outputs.packageName }}
+      tag: ${{ steps.setup-tag.outputs.tag }}
+      version: ${{ steps.setup-tag.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Setup package path
+        id: setup
+        run: echo "::set-output name=packageName::$(node -e "console.log(require('./package.json').name + '-' + require('./package.json').version + '.vsix')")"
+
+      - name: Package
+        env:
+          VSIX_PACKAGE_PATH: ${{ steps.setup.outputs.packageName }}
+        run: |
+          npm i -g vsce
+          vsce pacakge
+      
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.setup.outputs.packageName }}
+          path: ${{ steps.setup.outputs.packageName }}
+      
+      - name: Setup tag
+        id: setup-tag
+        run: |
+          $version = (Get-Content ./package.json -Raw | ConvertFrom-Json).version
+          Write-Host "tag: release/$version"
+          Write-Host "::set-output name=tag::release/$version"
+          Write-Host "::set-output name=version::$version"
+        shell: pwsh
+
+  publishMS:
+    name: Publish to MS marketplace
+    runs-on: ubuntu-latest
+    needs: package
+    if: github.event.inputs.publishMS == 'true'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.package.outputs.packageName }}
+      - name: Publish to MS marketplace
+        run: npx vsce publish --packagePath ./${{ needs.package.outputs.packageName }} -p ${{ secrets.VSCE_PAT }} 
+
+  publishOVSX:
+    name: Publish to OpenVSX
+    runs-on: ubuntu-latest
+    needs: package
+    if: github.event.inputs.publishOVSX == 'true'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.package.outputs.packageName }}
+      - name: Publish to OpenVSX
+        run: npx ovsx publish ./${{ needs.package.outputs.packageName }} -p ${{ secrets.OVSX_PAT }} 
+  
+  publishGH:
+    name: Publish to GitHub releases
+    runs-on: ubuntu-latest
+    needs: package
+    if: github.event.inputs.publishGH == 'true'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ needs.package.outputs.packageName }}
+
+      - name: Commit tagger
+        uses: tvdias/github-tagger@v0.0.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.package.outputs.tag }}
+          
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.package.outputs.tag }}
+          release_name: Release ${{ needs.package.outputs.version }}
+          draft: false
+          prerelease: false
+          
+      - name: Upload assets to a Release
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: ${{ needs.package.outputs.packageName }}
+          release-tag:  ${{ needs.package.outputs.tag }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GH action which can be executed to produce a new release. It consists of 4 jobs:

- package to prepare vsix file and upload it via the GitHub action
- publish to MS marketplace, one must configure a `VSCE_PAT` secret for this repo to make it work
- publish to OpenVSX, one must configure `OVSX_PAT` secret for this repo to make it work
- publish to GitHub releases, it will:
	- create a tag for a release to allow tracing from which commit the release was created 
	- as well as publish a new GitHub release with corresponding vsix file
Here is an example GH release: https://github.com/filiptronicek/NpmIntellisense/releases/tag/release%2F1.4.0
Runs of this workflow in the fork: https://github.com/filiptronicek/NpmIntellisense/blob/master/.github/workflows/publish.yml (It fails now because the publishing secrets are not configured).

Fixes #77 